### PR TITLE
Fix for https://github.com/kevinweil/hadoop-lzo/issues#issue/3

### DIFF
--- a/src/java/com/hadoop/compression/lzo/LzopInputStream.java
+++ b/src/java/com/hadoop/compression/lzo/LzopInputStream.java
@@ -186,7 +186,8 @@ public class LzopInputStream extends BlockDecompressorStream {
     hitem = readHeaderItem(in, buf, 1, adler, crc32); // fn len
     if (hitem > 0) {
       // skip filename
-      readHeaderItem(in, buf, hitem, adler, crc32);
+      int filenameLen = Math.max(4, hitem); // buffer must be at least 4 bytes for readHeaderItem to work.
+      readHeaderItem(in, new byte[filenameLen], hitem, adler, crc32);
     }
     int checksum = (int)(useCRC32 ? crc32.getValue() : adler.getValue());
     hitem = readHeaderItem(in, buf, 4, adler, crc32); // read checksum


### PR DESCRIPTION
In line 189 of LzopInputStream, "new byte[hitem]" is used instead of "buf" to invoke readHeaderItem. readHeaderItem in turn invokes readInt. For  readInt to work, buf must not be less than 4 bytes. hitem is the length of the original uncompressed file name. When hitem is less than 4, a ArrayIndexOutOfBoundsException is thrown. 
The fix simply changes "new byte[hitem]" to "buf".
