### PR TITLE
Added support for mixing LZO and non-LZO input files in a single streaming MR job + version bump to 0.14.4.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,7 +28,7 @@
  
   <property name="Name" value="Hadoop GPL Compression"/>
   <property name="name" value="hadoop-lzo"/>
-  <property name="version" value="0.4.13"/>
+  <property name="version" value="0.4.14"/>
   <property name="final.name" value="${name}-${version}"/>
   <property name="year" value="2008"/>
 


### PR DESCRIPTION
Added the boolean option "deprecated.lzo.text.input.format.ignore.non.lzo.extensions",
which defaults to true. The option is to be used with the
com.hadoop.mapred.DeprecatedLzoTextInputFormat input format class.

When true, it causes all files that don't end in ".lzo" to be silently dropped from
the input set.

When false, it will keep files that don't end in ".lzo", and will process them
with TextInputFormat (however, files that end in ".lzo.index" will still be ignored).
This makes it possible to process a mix of LZO and non-LZ) files with a single
streaming MR job.

Also bumped the version number to 0.4.14.
