### PR TITLE
Issue 30: Build fails on Ubuntu 11.10 (changed ld default behavior)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -247,6 +247,7 @@
     <exec dir="${build.native}" executable="sh" failonerror="true">
        <env key="OS_NAME" value="${os.name}"/>
        <env key="OS_ARCH" value="${os.arch}"/>
+       <env key="LDFLAGS" value="-Wl,--no-as-needed"/>
        <env key="JVM_DATA_MODEL" value="${sun.arch.data.model}"/>
        <env key="NATIVE_SRCDIR" value="${native.src.dir}"/>
        <arg line="${native.src.dir}/configure"/>


### PR DESCRIPTION
This patch explicitly sets the ld option '--no-as-needed'.  In Ubuntu
11.10, the default behavior of ld was changed to '--as-needed', which
breaks the src/native/configure script and its detection of the native
liblzo2 library.

More information is available at:
https://github.com/kevinweil/hadoop-lzo/issues/33
