### PR TITLE
Compress indexes

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,10 @@
+This product is distributed under the GNU General Public License (GPL v2+) (see COPYING).
+
+This product includes software developed by several Apache Software Foundation projects,
+licensed under the Apache License, 2.0, including but not limited to:
+  - Apache Mahout
+  - Apache Hadoop
+
+This product includes a JUnit jar: http://junit.sourceforge.net/
+License: Common Public License - v 1.0 (http://junit.sourceforge.net/cpl-v10.html)
+Copyright (c) 2000-2006, www.hamcrest.org

--- a/src/java/com/hadoop/compression/lzo/LzoBasicIndexSerde.java
+++ b/src/java/com/hadoop/compression/lzo/LzoBasicIndexSerde.java
@@ -96,8 +96,8 @@ public class LzoBasicIndexSerde implements LzoIndexSerde {
   }
 
   @Override
-  public int numBlocks() {
-    return numBlocks;
+  public void finishReading() throws IOException {
+    is.close();
   }
 
 }

--- a/src/java/com/hadoop/compression/lzo/LzoIndex.java
+++ b/src/java/com/hadoop/compression/lzo/LzoIndex.java
@@ -191,9 +191,17 @@ public class LzoIndex {
       }
     }
     serde.prepareToRead(indexIn);
-    LzoIndex index = new LzoIndex(serde.numBlocks());
-    for (int i = 0; i < serde.numBlocks(); i++) {
-      index.set(i, serde.next());
+    // Sized for at least 1 256MB HDFS block with 256KB Lzo blocks.
+    // if it's less than that, you shouldn't bother indexing anyway.
+    ArrayList<Long> offsets = new ArrayList<Long>(1024);
+    while (serde.hasNext()) {
+      offsets.add(serde.next());
+    }
+    serde.finishReading();
+
+    LzoIndex index = new LzoIndex(offsets.size());
+    for (int i = 0; i < offsets.size(); i++) {
+      index.set(i, offsets.get(i));
     }
     return index;
   }

--- a/src/java/com/hadoop/compression/lzo/LzoIndexSerde.java
+++ b/src/java/com/hadoop/compression/lzo/LzoIndexSerde.java
@@ -58,15 +58,10 @@ public interface LzoIndexSerde {
 
   public void finishWriting() throws IOException;
 
+  public void finishReading() throws IOException;
+
   public boolean hasNext() throws IOException;
 
   public long next() throws IOException;
-
-  /**
-   * Get the number of block expected to be read from this index.
-   * Will only be called after prepareToRead().
-   * @return number of block offsets that will be read back.
-   */
-  public int numBlocks();
 
 }

--- a/src/java/com/hadoop/compression/lzo/Varint.java
+++ b/src/java/com/hadoop/compression/lzo/Varint.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Varint code is taken from the Apache Mahout project under the
+ * Apache Software License.
+ * https://github.com/apache/mahout/blob/trunk/core/src/main/java/org/apache/mahout/math/Varint.java
+ *
+ * We've replace the guava Preconditions usage with simple if() {throw IllegalArgumentException} blocks.
+ * Other than that, it's a direct copy as of Feb 14 2012.
+ *
+ */
+
+package com.hadoop.compression.lzo;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+
+/**
+ * <p>Encodes signed and unsigned values using a common variable-length
+ * scheme, found for example in
+ * <a href="http://code.google.com/apis/protocolbuffers/docs/encoding.html">
+ * Google's Protocol Buffers</a>. It uses fewer bytes to encode smaller values,
+ * but will use slightly more bytes to encode large values.</p>
+ *
+ * <p>Signed values are further encoded using so-called zig-zag encoding
+ * in order to make them "compatible" with variable-length encoding.</p>
+ */
+public final class Varint {
+
+  private Varint() {
+  }
+
+  /**
+   * Encodes a value using the variable-length encoding from
+   * <a href="http://code.google.com/apis/protocolbuffers/docs/encoding.html">
+   * Google Protocol Buffers</a>. It uses zig-zag encoding to efficiently
+   * encode signed values. If values are known to be nonnegative,
+   * {@link #writeUnsignedVarLong(long, DataOutput)} should be used.
+   *
+   * @param value value to encode
+   * @param out to write bytes to
+   * @throws IOException if {@link DataOutput} throws {@link IOException}
+   */
+  public static void writeSignedVarLong(long value, DataOutput out) throws IOException {
+    // Great trick from http://code.google.com/apis/protocolbuffers/docs/encoding.html#types
+    writeUnsignedVarLong((value << 1) ^ (value >> 63), out);
+  }
+
+  /**
+   * Encodes a value using the variable-length encoding from
+   * <a href="http://code.google.com/apis/protocolbuffers/docs/encoding.html">
+   * Google Protocol Buffers</a>. Zig-zag is not used, so input must not be negative.
+   * If values can be negative, use {@link #writeSignedVarLong(long, DataOutput)}
+   * instead. This method treats negative input as like a large unsigned value.
+   *
+   * @param value value to encode
+   * @param out to write bytes to
+   * @throws IOException if {@link DataOutput} throws {@link IOException}
+   */
+  public static void writeUnsignedVarLong(long value, DataOutput out) throws IOException {
+    while ((value & 0xFFFFFFFFFFFFFF80L) != 0L) {
+      out.writeByte(((int) value & 0x7F) | 0x80);
+      value >>>= 7;
+    }
+    out.writeByte((int) value & 0x7F);
+  }
+
+  /**
+   * @see #writeSignedVarLong(long, DataOutput)
+   */
+  public static void writeSignedVarInt(int value, DataOutput out) throws IOException {
+    // Great trick from http://code.google.com/apis/protocolbuffers/docs/encoding.html#types
+    writeUnsignedVarInt((value << 1) ^ (value >> 31), out);
+  }
+
+  /**
+   * @see #writeUnsignedVarLong(long, DataOutput)
+   */
+  public static void writeUnsignedVarInt(int value, DataOutput out) throws IOException {
+    while ((value & 0xFFFFFF80) != 0L) {
+      out.writeByte((value & 0x7F) | 0x80);
+      value >>>= 7;
+    }
+    out.writeByte(value & 0x7F);
+  }
+
+  /**
+   * @param in to read bytes from
+   * @return decode value
+   * @throws IOException if {@link DataInput} throws {@link IOException}
+   * @throws IllegalArgumentException if variable-length value does not terminate
+   *  after 9 bytes have been read
+   * @see #writeSignedVarLong(long, DataOutput)
+   */
+  public static long readSignedVarLong(DataInput in) throws IOException {
+    long raw = readUnsignedVarLong(in);
+    // This undoes the trick in writeSignedVarLong()
+    long temp = (((raw << 63) >> 63) ^ raw) >> 1;
+    // This extra step lets us deal with the largest signed values by treating
+    // negative results from read unsigned methods as like unsigned values
+    // Must re-flip the top bit if the original read value had it set.
+    return temp ^ (raw & (1L << 63));
+  }
+
+  /**
+   * @param in to read bytes from
+   * @return decode value
+   * @throws IOException if {@link DataInput} throws {@link IOException}
+   * @throws IllegalArgumentException if variable-length value does not terminate
+   *  after 9 bytes have been read
+   * @see #writeUnsignedVarLong(long, DataOutput)
+   */
+  public static long readUnsignedVarLong(DataInput in) throws IOException {
+    long value = 0L;
+    int i = 0;
+    long b;
+    while (((b = in.readByte()) & 0x80L) != 0) {
+      value |= (b & 0x7F) << i;
+      i += 7;
+      if (i > 63) {
+        throw new IllegalArgumentException("Variable length quantity is too long");
+      }
+    }
+    return value | (b << i);
+  }
+
+  /**
+   * @throws IllegalArgumentException if variable-length value does not terminate
+   *  after 5 bytes have been read
+   * @throws IOException if {@link DataInput} throws {@link IOException}
+   * @see #readSignedVarLong(DataInput)
+   */
+  public static int readSignedVarInt(DataInput in) throws IOException {
+    int raw = readUnsignedVarInt(in);
+    // This undoes the trick in writeSignedVarInt()
+    int temp = (((raw << 31) >> 31) ^ raw) >> 1;
+    // This extra step lets us deal with the largest signed values by treating
+    // negative results from read unsigned methods as like unsigned values.
+    // Must re-flip the top bit if the original read value had it set.
+    return temp ^ (raw & (1 << 31));
+  }
+
+  /**
+   * @throws IllegalArgumentException if variable-length value does not terminate
+   *  after 5 bytes have been read
+   * @throws IOException if {@link DataInput} throws {@link IOException}
+   * @see #readUnsignedVarLong(DataInput)
+   */
+  public static int readUnsignedVarInt(DataInput in) throws IOException {
+    int value = 0;
+    int i = 0;
+    int b;
+    while (((b = in.readByte()) & 0x80) != 0) {
+      value |= (b & 0x7F) << i;
+      i += 7;
+      if (i > 35) {
+        throw new IllegalArgumentException("Variable length quantity is too long");
+      }
+    }
+    return value | (b << i);
+  }
+
+}

--- a/src/test/com/hadoop/compression/lzo/TestLzoIndexSerde.java
+++ b/src/test/com/hadoop/compression/lzo/TestLzoIndexSerde.java
@@ -59,7 +59,6 @@ public class TestLzoIndexSerde extends TestCase {
    long firstLong = is.readLong();
    assertTrue("Serde does not accept its own first long", serde.accepts(firstLong));
    serde.prepareToRead(is);
-   assertEquals("Serde reports different number of blocks than expected", expected.length, serde.numBlocks());
    for (long val : expected) {
      assertTrue("Serde does not return as many values as were written", serde.hasNext());
      assertEquals("Serde returned wrong offset", val, serde.next());


### PR DESCRIPTION
I added an interface to index reading/writing and provided an alternate representation of the index, which should drop the size of our index files about 4x.  Haven't tested on real data, but unit tests pass. Please comment.

TODO: make the order of index serdes tried configurable via properties a-la hadoop's compression, and make the writer configurable as well (right now I just hardcode the writer implementation).
