### PR TITLE
Stop explicitly setting configuration in DistributedLzoIndexer as its not necessary

### DIFF
--- a/src/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
+++ b/src/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
@@ -86,8 +86,7 @@ public class DistributedLzoIndexer extends Configured implements Tool {
       return 0;
     }
 
-    Configuration conf = new Configuration();
-    Job job = new Job(conf);
+    Job job = new Job(getConf());
     job.setJobName("Distributed Lzo Indexer " + Arrays.toString(args));
 
     job.setOutputKeyClass(Path.class);


### PR DESCRIPTION
This is related to https://github.com/twitter/hadoop-lzo/pull/48

Looking at ToolRunner, the configuration is already set, so this is not necessary. By updating in this way users can set the configuration if necessary too.
