### PR TITLE
add LOG.warn() about insufficiently large io.compression.codec.lzo.buffersize

### DIFF
--- a/src/java/com/hadoop/compression/lzo/LzoDecompressor.java
+++ b/src/java/com/hadoop/compression/lzo/LzoDecompressor.java
@@ -207,7 +207,7 @@ class LzoDecompressor implements Decompressor {
           len + " is greater than this decompressor's directBufferSize: " + 
           directBufferSize + ". To fix this, increase the value of your " + 
           "configuration's io.compression.codec.lzo.buffersize to be larger " +
-	  "than: " + len + ".")
+          "than: " + len + ".")
       }
     }
 


### PR DESCRIPTION
Addresses https://github.com/twitter/hadoop-lzo/issues/60.
