### PR TITLE
Hadoop 1.0.X throws FileNotFoundException on delete()

### DIFF
--- a/src/java/com/hadoop/mapreduce/LzoIndexRecordWriter.java
+++ b/src/java/com/hadoop/mapreduce/LzoIndexRecordWriter.java
@@ -1,5 +1,6 @@
 package com.hadoop.mapreduce;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import com.hadoop.compression.lzo.LzoIndex;
@@ -59,8 +60,13 @@ public class LzoIndexRecordWriter extends RecordWriter<Path, LongWritable> {
     realIndexPath = path.suffix(LzoIndex.LZO_INDEX_SUFFIX);
 
     // Delete the old index files if they exist.
-    fs.delete(tmpIndexPath, false);
-    fs.delete(realIndexPath, false);
+    try{
+        fs.delete(tmpIndexPath, false);
+    }catch(FileNotFoundException ignored){}
+
+    try{
+        fs.delete(realIndexPath, false);
+    }catch(FileNotFoundException ignored){}
 
     return fs.create(tmpIndexPath, false);
   }


### PR DESCRIPTION
I had to wrap the delete() call because hadoop is now throwing a FileNotFoundException.

try{
        fs.delete(tmpIndexPath, false);
    }catch(FileNotFoundException ignored){}

```
try{
    fs.delete(realIndexPath, false);
}catch(FileNotFoundException ignored){}
```
