### PR TITLE
Support Windows native build for hadoop-lzo.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 .archive-version export-subst
+
+# Auto detect text files and perform LF normalization
+*         text=auto
+*.sln     text merge=union eol=crlf
+*.vcxproj text merge=union eol=crlf

--- a/README.md
+++ b/README.md
@@ -29,12 +29,21 @@ LZO 2.x is required, and most easily installed via the package manager on your s
 1. Download the latest LZO release from http://www.oberhumer.com/opensource/lzo/
 1. Configure LZO to build a shared library (required) and use a package-specific prefix (optional but recommended): `./configure --enable-shared --prefix /usr/local/lzo-2.06`
 1. Build and install LZO: `make && sudo make install`
+1. On Windows, you can build lzo2.dll with this command: `B\win64\vc_dll.bat`
 
 Now let's build hadoop-lzo.
 
     C_INCLUDE_PATH=/usr/local/lzo-2.06/include \
     LIBRARY_PATH=/usr/local/lzo-2.06/lib \
       mvn clean test
+
+Running tests on Windows also requires setting PATH to include the location of lzo2.dll.
+
+    set PATH=C:\lzo-2.06;%PATH%
+
+Additionally on Windows, the Hadoop core code requires setting HADOOP_HOME so that the tests can find winutils.exe.  If you've built Hadoop trunk in directory C:\hdc, then the following would work.
+
+    set HADOOP_HOME=C:\hdc\hadoop-common-project\hadoop-common\target
 
 Once the libs are built and installed, you may want to add them to the class paths and library paths.  That is, in hadoop-env.sh, set
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <hadoop.current.version>2.1.0-beta</hadoop.current.version>
+    <hadoop.old.version>1.0.4</hadoop.old.version>
   </properties>
 
   <profiles>
@@ -100,13 +102,13 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
-          <version>2.0.4-alpha</version>
+          <version>${hadoop.current.version}</version>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-mapreduce-client-core</artifactId>
-          <version>2.0.4-alpha</version>
+          <version>${hadoop.current.version}</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>
@@ -120,13 +122,13 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-core</artifactId>
-          <version>1.0.4</version>
+          <version>${hadoop.old.version}</version>
           <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-test</artifactId>
-          <version>1.0.4</version>
+          <version>${hadoop.old.version}</version>
           <scope>provided</scope>
         </dependency>
       </dependencies>
@@ -147,17 +149,36 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
         <executions>
           <execution>
-            <id>set-props</id>
+            <id>check-platform</id>
             <phase>initialize</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <exportAntProperties>true</exportAntProperties>
-              <target name="set-props" description="sets key properties that are used throughout">
+              <target name="check-platform">
+                <condition property="windows">
+                  <os family="windows" />
+                </condition>
+                <condition property="non-windows">
+                  <not>
+                    <isset property="windows" />
+                  </not>
+                </condition>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>set-props-non-win</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target name="set-props-non-win" description="sets key properties that are used throughout" if="non-windows">
                 <exec executable="sed" inputstring="${os.name}" outputproperty="nonspace.os">
                   <arg value="s/ /_/g"/>
                 </exec>
@@ -170,17 +191,35 @@
             </configuration>
           </execution>
           <execution>
-            <id>build-info</id>
+            <id>set-props-win</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target name="set-props-win" description="sets key properties that are used throughout" if="windows">
+                <property name="build.native" value="${project.build.directory}/native/${env.OS}-${env.PLATFORM}"/>
+                <property name="native.src.dir" value="${basedir}/src/main/native"/>
+                <property name="test.build.dir" value="${project.build.directory}/test-classes"/>
+                <property name="test.log.dir" value="${test.build.dir}/logs"/>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-info-non-win</id>
             <phase>compile</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
-              <target name="build-info" description="generates build.properties">
+              <target name="build-info-non-win" description="generates build.properties" if="non-windows">
                 <tstamp>
                   <format property="build_time" pattern="MM/dd/yyyy hh:mm aa" timezone="GMT"/>
                 </tstamp>
-                <exec executable="${basedir}/scripts/get_build_revision.sh" outputproperty="build_revision"/>
+                <exec executable="sh" outputproperty="build_revision">
+                  <arg value="${basedir}/scripts/get_build_revision.sh" />
+                </exec>
                 <exec executable="whoami" outputproperty="build_author"/>
                 <exec executable="uname" outputproperty="build_os">
                   <arg value="-a"/>
@@ -197,28 +236,68 @@
             </configuration>
           </execution>
           <execution>
-            <id>check-native-uptodate</id>
+            <id>build-info-win</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="build-info-win" description="generates build.properties" if="windows">
+                <tstamp>
+                  <format property="build_time" pattern="MM/dd/yyyy hh:mm aa" timezone="GMT"/>
+                </tstamp>
+                <exec executable="sh" outputproperty="build_revision">
+                  <arg value="${basedir}/scripts/get_build_revision.sh" />
+                </exec>
+                <propertyfile file="${project.build.outputDirectory}/build.properties"
+                    comment="This file is automatically generated - DO NOT EDIT">
+                  <entry key="build_time" value="${build_time}"/>
+                  <entry key="build_revision" value="${build_revision}"/>
+                  <entry key="build_author" value="${env.USERNAME}"/>
+                  <entry key="build_version" value="${project.version}"/>
+                  <entry key="build_os" value="${env.OS}"/>
+                </propertyfile>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check-native-uptodate-non-win</id>
             <phase>compile</phase>
             <goals>
               <goal>run</goal>
             </goals>
             <configuration>
               <exportAntProperties>true</exportAntProperties>
-                <target name="check-native-uptodate" description="checks if native binaries should be rebuilt">
-                  <uptodate property="native.uptodate" targetfile="${build.native}/lib/libgplcompression.la">
-                    <srcfiles dir="${native.src.dir}" includes="**/*"/>
-                  </uptodate>
-                </target>
-              </configuration>
-            </execution>
-            <execution>
-              <id>build-native</id>
-              <phase>compile</phase>
-              <goals>
-                <goal>run</goal>
-              </goals>
-              <configuration>
-              <target name="build-native" unless="native.uptodate" description="compiles native code">
+              <target name="check-native-uptodate-non-win" description="checks if native binaries should be rebuilt" if="non-windows">
+                <uptodate property="native.uptodate" targetfile="${build.native}/lib/libgplcompression.la">
+                  <srcfiles dir="${native.src.dir}" includes="**/*"/>
+                </uptodate>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check-native-uptodate-win</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target name="check-native-uptodate-win" description="checks if native binaries should be rebuilt" if="windows">
+                <uptodate property="native.uptodate" targetfile="${build.native}/lib/gplcompression.dll">
+                  <srcfiles dir="${native.src.dir}" includes="**/*"/>
+                </uptodate>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-native-non-win</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="build-native-non-win" if="non-windows" unless="native.uptodate" description="compiles native code">
                 <property name="make.cmd" value="make"/>
                 <property name="build.classes" refid="maven.compile.classpath"/>
                 <condition property="native.ldflags" value="" else="-Wl,--no-as-needed">
@@ -255,6 +334,39 @@
                 <exec dir="${build.native}" executable="sh" failonerror="true">
                   <arg line="${build.native}/libtool --mode=install cp ${build.native}/libgplcompression.la ${build.native}/lib"/>
                 </exec>
+              </target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-native-win</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target name="build-native-win" unless="native.uptodate" if="windows" description="compiles native code">
+                <property name="build.classes" refid="maven.compile.classpath"/>
+
+                <mkdir dir="${build.native}/lib"/>
+                <mkdir dir="${build.native}/src/com/hadoop/compression/lzo"/>
+
+                <javah classpath="${build.classes}"
+                    destdir="${build.native}/src/com/hadoop/compression/lzo"
+                    force="yes"
+                    verbose="yes">
+                  <class name="com.hadoop.compression.lzo.LzoCompressor" />
+                  <class name="com.hadoop.compression.lzo.LzoDecompressor" />
+                </javah>
+
+                <exec dir="${build.native}" executable="msbuild" failonerror="true">
+                  <arg value="${basedir}/src/main/native/gplcompression.sln" />
+                  <arg value="/nologo" />
+                  <arg value="/p:Configuration=Release" />
+                  <arg value="/p:IntDir=${build.native}/" />
+                  <arg value="/p:OutDir=${build.native}/" />
+                </exec>
+
+                <copy file="${build.native}/gplcompression.dll" todir="${build.native}/lib" />
               </target>
             </configuration>
           </execution>
@@ -355,6 +467,16 @@
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.3.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
@@ -55,6 +55,7 @@ class LzoCompressor implements Compressor {
   @SuppressWarnings("unused")
   private long lzoCompressor = 0;       // The actual lzo compression function.
   private int workingMemoryBufLen = 0;  // The length of 'working memory' buf.
+  private long lzoCompressLevelFunc = 0; // The lzo compression level function.
   @SuppressWarnings("unused")
   private ByteBuffer workingMemoryBuf;      // The 'working memory' for lzo.
   private int lzoCompressionLevel;

--- a/src/main/native/gplcompression.sln
+++ b/src/main/native/gplcompression.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+
+# This file is part of Hadoop-Gpl-Compression.
+#
+# Hadoop-Gpl-Compression is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Hadoop-Gpl-Compression is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Hadoop-Gpl-Compression.  If not, see
+# <http://www.gnu.org/licenses/>.
+
+Project("{EAAEC089-7163-4E57-96A1-B61BF66B3F72}") = "gplcompression", "gplcompression.vcxproj", "{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Debug|Win32.ActiveCfg = Release|x64
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Debug|Win32.Build.0 = Release|x64
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Debug|x64.ActiveCfg = Debug|x64
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Debug|x64.Build.0 = Debug|x64
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Release|Win32.ActiveCfg = Release|Win32
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Release|Win32.Build.0 = Release|Win32
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Release|x64.ActiveCfg = Release|x64
+		{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/main/native/gplcompression.vcxproj
+++ b/src/main/native/gplcompression.vcxproj
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  This file is part of Hadoop-Gpl-Compression.
+ 
+  Hadoop-Gpl-Compression is free software: you can redistribute it
+  and/or modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation, either version 3 of
+  the License, or (at your option) any later version.
+ 
+  Hadoop-Gpl-Compression is distributed in the hope that it will be
+  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+ 
+  You should have received a copy of the GNU General Public License
+  along with Hadoop-Gpl-Compression.  If not, see
+  <http://www.gnu.org/licenses/>.
+-->
+
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>gplcompression</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IncludePath>%C_INCLUDE_PATH%;%JAVA_HOME%\include;%JAVA_HOME%\include\win32;.\impl;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="impl\lzo\LzoCompressor.c">
+      <AdditionalOptions>/D HADOOP_LZO_LIBRARY=L\"lzo2.dll\"</AdditionalOptions>
+    </ClCompile>
+    <ClCompile Include="impl\lzo\LzoDecompressor.c">
+      <AdditionalOptions>/D HADOOP_LZO_LIBRARY=L\"lzo2.dll\"</AdditionalOptions>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="impl\gpl-compression.h" />
+    <ClInclude Include="impl\lzo\lzo.h" />
+    <ClInclude Include="impl\lzo\lzo.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/main/native/impl/gpl-compression.h
+++ b/src/main/native/impl/gpl-compression.h
@@ -23,9 +23,15 @@
 #if !defined GPL_COMPRESSION_H
 #define GPL_COMPRESSION_H
 
-#include <config.h>
-#include <dlfcn.h>
-#include <jni.h>
+#if defined(_WIN32)
+#undef UNIX
+#define WINDOWS
+#else
+#undef WINDOWS
+#define UNIX
+#endif
+
+#include "lzo/lzo.h"
 
 /* A helper macro to 'throw' a java exception. */ 
 #define THROW(env, exception_name, message) \
@@ -36,6 +42,14 @@
 	  (*env)->DeleteLocalRef(env, ecls); \
 	} \
   }
+
+/**
+ * Unix definitions
+ */
+#ifdef UNIX
+#include <config.h>
+#include <dlfcn.h>
+#include <jni.h>
 
 /** 
  * A helper function to dlsym a 'symbol' from a given library-handle. 
@@ -66,6 +80,60 @@ static void *do_dlsym(JNIEnv *env, void *handle, const char *symbol) {
   if ((func_ptr = do_dlsym(env, handle, symbol)) == NULL) { \
     return; \
   }
+#endif
+// Unix part end
+
+
+/**
+ * Windows definitions
+ */
+#ifdef WINDOWS
+
+/* Force using Unicode throughout the code */
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include <Windows.h>
+#include <stdio.h>
+#include <jni.h>
+
+#define snprintf(a, b ,c, d) _snprintf_s((a), (b), _TRUNCATE, (c), (d))
+
+/* A helper macro to dlsym the requisite dynamic symbol and bail-out on error. */
+#define LOAD_DYNAMIC_SYMBOL(func_type, func_ptr, env, handle, symbol) \
+  if ((func_ptr = (func_type) do_dlsym(env, handle, symbol)) == NULL) { \
+    return; \
+  }
+
+/**
+ * A helper function to dynamic load a 'symbol' from a given library-handle.
+ *
+ * @param env jni handle to report contingencies.
+ * @param handle handle to the dynamic library.
+ * @param symbol symbol to load.
+ * @return returns the address where the symbol is loaded in memory,
+ *         <code>NULL</code> on error.
+ */
+static FARPROC WINAPI do_dlsym(JNIEnv *env, HMODULE handle, LPCSTR symbol) {
+  DWORD dwErrorCode = ERROR_SUCCESS;
+  FARPROC func_ptr = NULL;
+
+  if (!env || !handle || !symbol) {
+    THROW(env, "java/lang/InternalError", NULL);
+    return NULL;
+  }
+
+  func_ptr = GetProcAddress(handle, symbol);
+  if (func_ptr == NULL)
+  {
+    THROW(env, "java/lang/UnsatisfiedLinkError", symbol);
+  }
+  return func_ptr;
+}
+#endif
+// Windows part end
+
 
 #define LOCK_CLASS(env, clazz, classname) \
   if ((*env)->MonitorEnter(env, clazz) != 0) { \
@@ -86,6 +154,18 @@ static void *do_dlsym(JNIEnv *env, void *handle, const char *symbol) {
 
 /* A helper macro to convert the void* to the java 'function-pointer'. */
 #define JLONG(func_ptr) ((jlong)((ptrdiff_t)(func_ptr)))
+
+// type of pointer to lzo function that returns version number
+typedef unsigned (__LZO_CDECL *lzo_version_t)();
+
+// type of pointer to lzo initialization function
+typedef int (__LZO_CDECL *lzo_init_t)(unsigned, int, int, int, int, int, int,
+  int, int, int);
+
+// type of pointer to compression level function
+typedef int (__LZO_CDECL *lzo_compress_level_t)(const lzo_bytep, lzo_uint,
+  lzo_bytep, lzo_uintp, lzo_voidp, const lzo_bytep, lzo_uint, lzo_callback_p,
+  int);
 
 #endif
 

--- a/src/main/native/impl/lzo/LzoDecompressor.c
+++ b/src/main/native/impl/lzo/LzoDecompressor.c
@@ -25,6 +25,8 @@ static void *liblzo2 = NULL;
 // lzo2 library version
 static jint liblzo2_version = 0;
 
+#define MSG_LEN 1024
+
 // The lzo 'decompressors'
 static char* lzo_decompressors[] = {
   /** lzo1 decompressors */
@@ -86,6 +88,9 @@ JNIEXPORT void JNICALL
 Java_com_hadoop_compression_lzo_LzoDecompressor_initIDs(
 	JNIEnv *env, jclass class
 	) {
+  void* lzo_version_ptr = NULL;
+
+#ifdef UNIX
 	// Load liblzo2.so
 	liblzo2 = dlopen(HADOOP_LZO_LIBRARY, RTLD_LAZY | RTLD_GLOBAL);
 	if (!liblzo2) {
@@ -95,6 +100,15 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_initIDs(
     free(msg);
 	  return;
 	}
+#endif
+
+#ifdef WINDOWS
+  liblzo2 = LoadLibrary(HADOOP_LZO_LIBRARY);
+  if (!liblzo2) {
+    THROW(env, "java/lang/UnsatisfiedLinkError", "Cannot load lzo2.dll");
+    return;
+  }
+#endif
     
   LzoDecompressor_clazz = (*env)->GetStaticFieldID(env, class, "clazz", 
                                                    "Ljava/lang/Class;");
@@ -113,27 +127,44 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_initIDs(
                                               "lzoDecompressor", "J");
 
   // record lzo library version
-  void* lzo_version_ptr = NULL;
+#ifdef UNIX
   LOAD_DYNAMIC_SYMBOL(lzo_version_ptr, env, liblzo2, "lzo_version");
+#endif
+
+#ifdef WINDOWS
+  LOAD_DYNAMIC_SYMBOL(lzo_version_t, lzo_version_ptr, env, liblzo2,
+    "lzo_version");
+#endif
+
   liblzo2_version = (NULL == lzo_version_ptr) ? 0
-    : (jint) ((unsigned (__LZO_CDECL *)())lzo_version_ptr)();
+    : (jint) ((lzo_version_t)lzo_version_ptr)();
 }
 
 JNIEXPORT void JNICALL
 Java_com_hadoop_compression_lzo_LzoDecompressor_init(
   JNIEnv *env, jobject this, jint decompressor 
   ) {
+  void *lzo_init_func_ptr = NULL;
+  lzo_init_t lzo_init_function = NULL;
+  void *decompressor_func_ptr = NULL;
+  int rv = 0;
   const char *lzo_decompressor_function = lzo_decompressors[decompressor];
  
   // Locate the requisite symbols from liblzo2.so
-  dlerror();                                 // Clear any existing error
 
   // Initialize the lzo library 
-  void *lzo_init_func_ptr = NULL;
-  typedef int (__LZO_CDECL *lzo_init_t) (unsigned,int,int,int,int,int,int,int,int,int);
+
+#ifdef UNIX
+  dlerror();                                 // Clear any existing error
   LOAD_DYNAMIC_SYMBOL(lzo_init_func_ptr, env, liblzo2, "__lzo_init_v2");
-  lzo_init_t lzo_init_function = (lzo_init_t)(lzo_init_func_ptr);
-  int rv = lzo_init_function(LZO_VERSION, (int)sizeof(short), (int)sizeof(int), 
+#endif
+
+#ifdef WINDOWS
+  LOAD_DYNAMIC_SYMBOL(lzo_init_t, lzo_init_func_ptr, env, liblzo2, "__lzo_init_v2");
+#endif
+
+  lzo_init_function = (lzo_init_t)(lzo_init_func_ptr);
+  rv = lzo_init_function(LZO_VERSION, (int)sizeof(short), (int)sizeof(int), 
               (int)sizeof(long), (int)sizeof(lzo_uint32), (int)sizeof(lzo_uint), 
               (int)lzo_sizeof_dict_t, (int)sizeof(char*), (int)sizeof(lzo_voidp),
               (int)sizeof(lzo_callback_t));
@@ -143,9 +174,16 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_init(
   }
   
   // Save the decompressor-function into LzoDecompressor_lzoDecompressor
-  void *decompressor_func_ptr = NULL;
+#ifdef UNIX
   LOAD_DYNAMIC_SYMBOL(decompressor_func_ptr, env, liblzo2,
       lzo_decompressor_function);
+#endif
+
+#ifdef WINDOWS
+  LOAD_DYNAMIC_SYMBOL(void *, decompressor_func_ptr, env, liblzo2,
+      lzo_decompressor_function);
+#endif
+
   (*env)->SetLongField(env, this, LzoDecompressor_lzoDecompressor,
                        JLONG(decompressor_func_ptr));
 
@@ -162,27 +200,39 @@ JNIEXPORT jint JNICALL
 Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
 	JNIEnv *env, jobject this, jint decompressor
 	) {
+  jobject clazz = NULL;
+  jobject compressed_direct_buf = NULL;
+  lzo_uint compressed_direct_buf_len = 0;
+  jobject uncompressed_direct_buf = NULL;
+  lzo_uint uncompressed_direct_buf_len = 0;
+  jlong lzo_decompressor_funcptr = 0;
+  lzo_bytep uncompressed_bytes = NULL;
+  lzo_bytep compressed_bytes = NULL;
+  lzo_uint no_uncompressed_bytes = 0;
+  lzo_decompress_t fptr = NULL;
+  int rv = 0;
+  char exception_msg[MSG_LEN];
   const char *lzo_decompressor_function = lzo_decompressors[decompressor];
 
 	// Get members of LzoDecompressor
-	jobject clazz = (*env)->GetStaticObjectField(env, this, 
+	clazz = (*env)->GetStaticObjectField(env, this, 
 	                                             LzoDecompressor_clazz);
-	jobject compressed_direct_buf = (*env)->GetObjectField(env, this,
+	compressed_direct_buf = (*env)->GetObjectField(env, this,
                                               LzoDecompressor_compressedDirectBuf);
-	lzo_uint compressed_direct_buf_len = (*env)->GetIntField(env, this, 
+	compressed_direct_buf_len = (*env)->GetIntField(env, this, 
                         		  							LzoDecompressor_compressedDirectBufLen);
 
-	jobject uncompressed_direct_buf = (*env)->GetObjectField(env, this, 
+	uncompressed_direct_buf = (*env)->GetObjectField(env, this, 
                             								  LzoDecompressor_uncompressedDirectBuf);
-	lzo_uint uncompressed_direct_buf_len = (*env)->GetIntField(env, this,
+	uncompressed_direct_buf_len = (*env)->GetIntField(env, this,
                                                 LzoDecompressor_directBufferSize);
 
-  jlong lzo_decompressor_funcptr = (*env)->GetLongField(env, this,
+  lzo_decompressor_funcptr = (*env)->GetLongField(env, this,
                                               LzoDecompressor_lzoDecompressor);
 
     // Get the input direct buffer
     LOCK_CLASS(env, clazz, "LzoDecompressor");
-	lzo_bytep uncompressed_bytes = (*env)->GetDirectBufferAddress(env, 
+	uncompressed_bytes = (*env)->GetDirectBufferAddress(env, 
 											                    uncompressed_direct_buf);
     UNLOCK_CLASS(env, clazz, "LzoDecompressor");
     
@@ -192,7 +242,7 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
 	
     // Get the output direct buffer
     LOCK_CLASS(env, clazz, "LzoDecompressor");
-	lzo_bytep compressed_bytes = (*env)->GetDirectBufferAddress(env, 
+	compressed_bytes = (*env)->GetDirectBufferAddress(env, 
 										                    compressed_direct_buf);
     UNLOCK_CLASS(env, clazz, "LzoDecompressor");
 
@@ -201,24 +251,29 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
 	}
 	
 	// Decompress
-  lzo_uint no_uncompressed_bytes = uncompressed_direct_buf_len;
-  lzo_decompress_t fptr = (lzo_decompress_t) FUNC_PTR(lzo_decompressor_funcptr);
-	int rv = fptr(compressed_bytes, compressed_direct_buf_len,
-                uncompressed_bytes, &no_uncompressed_bytes,
-                NULL); 
+  no_uncompressed_bytes = uncompressed_direct_buf_len;
+  fptr = (lzo_decompress_t) FUNC_PTR(lzo_decompressor_funcptr);
+  rv = fptr(compressed_bytes, compressed_direct_buf_len, uncompressed_bytes,
+    &no_uncompressed_bytes, NULL); 
 
   if (rv == LZO_E_OK) {
     // lzo decompresses all input data
     (*env)->SetIntField(env, this, LzoDecompressor_compressedDirectBufLen, 0);
   } else {
-    const int msg_len = 1024;
-    char exception_msg[msg_len];
-    snprintf(exception_msg, msg_len, "%s returned: %d", 
+#ifdef UNIX
+    snprintf(exception_msg, MSG_LEN, "%s returned: %d", 
               lzo_decompressor_function, rv);
+#endif
+
+#ifdef WINDOWS
+    _snprintf_s(exception_msg, MSG_LEN, _TRUNCATE, "%s returned: %d",
+      lzo_decompressor_function, rv);
+#endif
+
     THROW(env, "java/lang/InternalError", exception_msg);
   }
   
-  return no_uncompressed_bytes;
+  return (jint)no_uncompressed_bytes;
 }
 
 /**

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,22 @@
+# This file is part of Hadoop-Gpl-Compression.
+#
+# Hadoop-Gpl-Compression is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Hadoop-Gpl-Compression is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Hadoop-Gpl-Compression.  If not, see
+# <http://www.gnu.org/licenses/>.
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=info,stdout
+log4j.threshhold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n


### PR DESCRIPTION
This patch updates the lzo codec for compatibility with Windows.

Summary of changes in this patch:
1. Add Visual Studio project files.
2. Split pom.xml Ant tasks into 2 platforms-specific paths: native-non-win (existing build) and win (new Windows logic to call msbuild).
3. Update build instructions with some Windows-specific information.
4. Update C code to enable calling Windows dynamic library loading functions.
5. Change call to lzo1x_999_compress_level to use dynamic linking. Otherwise, I'd get a linker error on Windows.
6. The MS compiler doesn't support C99, so I made a lot of small changes to satisfy the compiler, such as moving variable declarations to the top of functions.
7. Some minor refactoring to lift function pointer specs into typedefs in a header.
8. Added a log4j.properties to see log output during test runs.

I ran a full build and all unit tests passed on Windows and Linux with both default-profile and hadoop-old. To run the tests on Windows, you'll need to set the C_INCLUDE_PATH environment variable to the location of the lzo headers. (This is consistent with the existing convention for the Linux build.) You'll also need to set PATH to include the location of your lzo2.dll. Additionally, you'll also need to set the HADOOP_HOME environment variable so that winutils.exe can be found while running the tests. I documented all of this in README.md.

I also ran end-to-end testing of some word count and grep map-reduce jobs using the codec and both indexers.
