### PR TITLE
ignore decompressor error

### DIFF
--- a/src/main/native/impl/lzo/LzoDecompressor.c
+++ b/src/main/native/impl/lzo/LzoDecompressor.c
@@ -256,23 +256,9 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
   rv = fptr(compressed_bytes, compressed_direct_buf_len, uncompressed_bytes,
     &no_uncompressed_bytes, NULL); 
 
-  if (rv == LZO_E_OK) {
-    // lzo decompresses all input data
-    (*env)->SetIntField(env, this, LzoDecompressor_compressedDirectBufLen, 0);
-  } else {
-#ifdef UNIX
-    snprintf(exception_msg, MSG_LEN, "%s returned: %d", 
-              lzo_decompressor_function, rv);
-#endif
+  // lzo decompresses all input data
+  (*env)->SetIntField(env, this, LzoDecompressor_compressedDirectBufLen, 0);
 
-#ifdef WINDOWS
-    _snprintf_s(exception_msg, MSG_LEN, _TRUNCATE, "%s returned: %d",
-      lzo_decompressor_function, rv);
-#endif
-
-    THROW(env, "java/lang/InternalError", exception_msg);
-  }
-  
   return (jint)no_uncompressed_bytes;
 }
 


### PR DESCRIPTION
We use flume to write lzo compressed logs to hdfs and hive to analysis these logs. I find hive sql sometimes fail due to the following errors. We can tolerate a few lines of error log, but can not tolerate sql execution failure. And may be it's better to add a parameter to config whether ignoring decompress error. I'm not a expert, any suggestions? BTW, I can't attach the error lzo file, github doesn't allow to upload files except images.

{code}
2013-11-27 20:48:24,060 FATAL org.apache.hadoop.mapred.Child: Error running child : java.lang.InternalError: lzo1x_decompress_safe returned: -6
    at com.hadoop.compression.lzo.LzoDecompressor.decompressBytesDirect(Native Method)
    at com.hadoop.compression.lzo.LzoDecompressor.decompress(LzoDecompressor.java:316)
    at com.hadoop.compression.lzo.LzopDecompressor.decompress(LzopDecompressor.java:122)
    at com.hadoop.compression.lzo.LzopInputStream.decompress(LzopInputStream.java:247)
    at org.apache.hadoop.io.compress.DecompressorStream.read(DecompressorStream.java:76)
    at java.io.InputStream.read(InputStream.java:101)
    at org.apache.hadoop.util.LineReader.readLine(LineReader.java:134)
    at org.apache.hadoop.util.LineReader.readLine(LineReader.java:187)
    at com.hadoop.mapred.DeprecatedLzoLineRecordReader.next(DeprecatedLzoLineRecordReader.java:85)
    at com.hadoop.mapred.DeprecatedLzoLineRecordReader.next(DeprecatedLzoLineRecordReader.java:35)
    at org.apache.hadoop.hive.ql.io.HiveContextAwareRecordReader.doNext(HiveContextAwareRecordReader.java:274)
    at org.apache.hadoop.hive.ql.io.HiveRecordReader.doNext(HiveRecordReader.java:79)
    at org.apache.hadoop.hive.ql.io.HiveRecordReader.doNext(HiveRecordReader.java:33)
    at org.apache.hadoop.hive.ql.io.HiveContextAwareRecordReader.next(HiveContextAwareRecordReader.java:108)
    at org.apache.hadoop.mapred.MapTask$TrackedRecordReader.moveToNext(MapTask.java:236)
    at org.apache.hadoop.mapred.MapTask$TrackedRecordReader.next(MapTask.java:216)
    at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:48)
    at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:436)
    at org.apache.hadoop.mapred.MapTask.run(MapTask.java:372)
    at org.apache.hadoop.mapred.Child$4.run(Child.java:255)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:415)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1093)
    at org.apache.hadoop.mapred.Child.main(Child.java:249)
{code}
