### PR TITLE
Fix lzop header when strategy is LZO1X_999

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
@@ -285,6 +285,10 @@ class LzoCompressor implements Compressor {
     this(CompressionStrategy.LZO1X_1, 64*1024);
   }
 
+  public int getCompressionLevel() {
+    return this.lzoCompressionLevel;
+  }
+
   public synchronized void setInput(byte[] b, int off, int len) {
     if (b== null) {
       throw new NullPointerException();

--- a/src/main/java/com/hadoop/compression/lzo/LzopOutputStream.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopOutputStream.java
@@ -41,7 +41,8 @@ public class LzopOutputStream extends CompressorStream {
    * @throws IOException if lzop strategy is incompatible 
    */
   protected static void writeLzopHeader(OutputStream out,
-          LzoCompressor.CompressionStrategy strategy) throws IOException {
+          LzoCompressor.CompressionStrategy strategy,
+          int compressionLevel) throws IOException {
     DataOutputBuffer dob = new DataOutputBuffer();
     try {
       dob.writeShort(LzopCodec.LZOP_VERSION);
@@ -58,7 +59,7 @@ public class LzopOutputStream extends CompressorStream {
         break;
       case LZO1X_999:
         dob.writeByte(3);
-        dob.writeByte(9);
+        dob.writeByte((byte) compressionLevel);
         break;
       default:
         throw new IOException("Incompatible lzop strategy: " + strategy);
@@ -97,7 +98,9 @@ public class LzopOutputStream extends CompressorStream {
       (bufferSize >> 4) + 64 + 3 : (bufferSize >> 3) + 128 + 3;
     MAX_INPUT_SIZE = bufferSize - overhead;
 
-    writeLzopHeader(this.out, strategy);
+    int compressionLevel = ((LzoCompressor) compressor).getCompressionLevel();
+
+    writeLzopHeader(this.out, strategy, compressionLevel);
   }
 
   /**


### PR DESCRIPTION
LzopOutputStream doesn't set the header correctly when strategy is set to LZO1X_999: the compression level is always set to 9 in the header.