### PR TITLE
include power8 (ppc64le) case in config.guess

### DIFF
--- a/src/main/native/config/config.guess
+++ b/src/main/native/config/config.guess
@@ -906,6 +906,9 @@ EOF
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-${LIBC}
 	exit 0 ;;
+    ppc64le:Linux:*:*)
+	echo powerpc64le-unknown-linux-${LIBC}
+	exit 0 ;;
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;


### PR DESCRIPTION
The config.guess included here pretty old (timestamp='2005-02-10').  Attempting to build on a Power8 machine fails like this:

    $ mvn clean test
    ...
     [exec] UNAME_MACHINE = ppc64le
     [exec] UNAME_RELEASE = 3.13.0-66-generic
     [exec] UNAME_SYSTEM  = Linux
     [exec] UNAME_VERSION = #108-Ubuntu SMP Wed Oct 7 16:06:09 UTC 2015
     [exec] configure: error: cannot guess build type; you must specify one
    ...
    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (build-native-non-win) on project hadoop-lzo: An Ant BuildException has occured: exec returned: 1

This commit will fix the build error on ppc64le platforms, but you may also want to consider grabbing a newer config.guess that includes support for other hardware platforms.