### PR TITLE
Added aarch64 build support

### DIFF
--- a/src/main/native/Makefile.am
+++ b/src/main/native/Makefile.am
@@ -17,7 +17,10 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo
 AM_LDFLAGS = @JNI_LDFLAGS@
-AM_CFLAGS = -g -Wall -fPIC -O2 -m$(JVM_DATA_MODEL)
+AM_CFLAGS = -g -Wall -fPIC -O2
+ifneq ($(OS_ARCH),aarch64)
+  AM_CFLAGS += -m$(JVM_DATA_MODEL)
+endif
 
 # Define the libaries that need to be built
 lib_LTLIBRARIES = libgplcompression.la

--- a/src/main/native/Makefile.in
+++ b/src/main/native/Makefile.in
@@ -228,7 +228,11 @@ top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo
 AM_LDFLAGS = @JNI_LDFLAGS@
-AM_CFLAGS = -g -Wall -fPIC -O2 -m$(JVM_DATA_MODEL)
+AM_CFLAGS = -g -Wall -fPIC -O2
+ifneq ($(OS_ARCH),aarch64)
+  AM_CFLAGS += -m$(JVM_DATA_MODEL)
+endif
+
 
 # Define the libaries that need to be built
 lib_LTLIBRARIES = libgplcompression.la

--- a/src/main/native/config/config.guess
+++ b/src/main/native/config/config.guess
@@ -844,6 +844,9 @@ EOF
     arm*:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
 	exit 0 ;;
+    aarch64:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
+	exit 0 ;;
     cris:Linux:*:*)
 	echo cris-axis-linux-${LIBC}
 	exit 0 ;;


### PR DESCRIPTION
I attempted to build on aarch64, which resulted in this failure:

$ mvn clean test
...
     [exec] UNAME_MACHINE = aarch64
     [exec] UNAME_RELEASE = 3.13.0-86-generic
     [exec] UNAME_SYSTEM  = Linux
     [exec] UNAME_VERSION = #130-Ubuntu SMP Mon Apr 18 18:25:33 UTC 2016
     [exec] configure: error: cannot guess build type; you must specify one...
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run (build-native-non-win) on project hadoop-lzo: An Ant BuildException has occured: exec returned: 1
[ERROR] around Ant part ...<exec dir="${build.native}" executable="sh" failonerror="true">... @ 16:66 in /home/ubuntu/hadoop-lzo/target/antrun/build-build-native-non-win.xml

I added aarch64 to config.guess and modified the Makefile.in/am files to handle the missing '-m' argument with aarch64's gcc.

I've verified the resulting plugin on my aarch64 hadoop cluster.