### PR TITLE
Default job name length for DistributedLzoIndexer

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
+++ b/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
@@ -26,7 +26,13 @@ import org.apache.hadoop.util.ToolRunner;
 
 public class DistributedLzoIndexer extends Configured implements Tool {
   private static final Log LOG = LogFactory.getLog(DistributedLzoIndexer.class);
+  /**
+   * Override the default job name which is generated from the arguments.
+   */
   public static final String JOB_NAME_KEY = "lzo.indexer.distributed.job.name";
+  /**
+   * Override the default length to which the job name will be truncated. Set non-positive to disable.
+   */
   public static final String JOB_NAME_MAX_LENGTH_KEY = "lzo.indexer.distributed.job.name.max.length";
   private static final int DEFAULT_JOB_NAME_MAX_LENGTH = 200;
   private final String LZO_EXTENSION = new LzopCodec().getDefaultExtension();
@@ -77,7 +83,7 @@ public class DistributedLzoIndexer extends Configured implements Tool {
 
     final int maxLength = conf.getInt(JOB_NAME_MAX_LENGTH_KEY, DEFAULT_JOB_NAME_MAX_LENGTH);
 
-    if (name.length() > maxLength) {
+    if (maxLength > 0 && name.length() > maxLength) {
       name = name.substring(0, maxLength) + "...";
     }
 

--- a/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
+++ b/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
@@ -34,6 +34,7 @@ public class DistributedLzoIndexer extends Configured implements Tool {
    * Override the default length to which the job name will be truncated. Set non-positive to disable.
    */
   public static final String JOB_NAME_MAX_LENGTH_KEY = "lzo.indexer.distributed.job.name.max.length";
+  static final String DEFAULT_JOB_NAME_PREFIX = "Distributed Lzo Indexer";
   private static final int DEFAULT_JOB_NAME_MAX_LENGTH = 200;
   private final String LZO_EXTENSION = new LzopCodec().getDefaultExtension();
 
@@ -79,7 +80,7 @@ public class DistributedLzoIndexer extends Configured implements Tool {
   static void setJobName(Job job, String[] args) {
     final Configuration conf = job.getConfiguration();
 
-    String name = conf.get(JOB_NAME_KEY, "Distributed Lzo Indexer " + Arrays.toString(args));
+    String name = conf.get(JOB_NAME_KEY, DEFAULT_JOB_NAME_PREFIX + " " + Arrays.toString(args));
 
     final int maxLength = conf.getInt(JOB_NAME_MAX_LENGTH_KEY, DEFAULT_JOB_NAME_MAX_LENGTH);
 

--- a/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
+++ b/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
@@ -11,6 +11,7 @@ import com.hadoop.mapreduce.LzoSplitInputFormat;
 import com.hadoop.mapreduce.LzoSplitRecordReader;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -69,10 +70,13 @@ public class DistributedLzoIndexer extends Configured implements Tool {
     }
   }
 
-  private void setJobName(Job job, String[] args) {
-    String name = getConf().get(JOB_NAME_KEY, "Distributed Lzo Indexer " + Arrays.toString(args));
+  static void setJobName(Job job, String[] args) {
+    final Configuration conf = job.getConfiguration();
 
-    int maxLength = getConf().getInt(JOB_NAME_MAX_LENGTH_KEY, DEFAULT_JOB_NAME_MAX_LENGTH);
+    String name = conf.get(JOB_NAME_KEY, "Distributed Lzo Indexer " + Arrays.toString(args));
+
+    final int maxLength = conf.getInt(JOB_NAME_MAX_LENGTH_KEY, DEFAULT_JOB_NAME_MAX_LENGTH);
+
     if (name.length() > maxLength) {
       name = name.substring(0, maxLength) + "...";
     }

--- a/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
+++ b/src/main/java/com/hadoop/compression/lzo/DistributedLzoIndexer.java
@@ -25,6 +25,9 @@ import org.apache.hadoop.util.ToolRunner;
 
 public class DistributedLzoIndexer extends Configured implements Tool {
   private static final Log LOG = LogFactory.getLog(DistributedLzoIndexer.class);
+  public static final String JOB_NAME_KEY = "lzo.indexer.distributed.job.name";
+  public static final String JOB_NAME_MAX_LENGTH_KEY = "lzo.indexer.distributed.job.name.max.length";
+  private static final int DEFAULT_JOB_NAME_MAX_LENGTH = 200;
   private final String LZO_EXTENSION = new LzopCodec().getDefaultExtension();
 
   private final PathFilter nonTemporaryFilter = new PathFilter() {
@@ -66,6 +69,17 @@ public class DistributedLzoIndexer extends Configured implements Tool {
     }
   }
 
+  private void setJobName(Job job, String[] args) {
+    String name = getConf().get(JOB_NAME_KEY, "Distributed Lzo Indexer " + Arrays.toString(args));
+
+    int maxLength = getConf().getInt(JOB_NAME_MAX_LENGTH_KEY, DEFAULT_JOB_NAME_MAX_LENGTH);
+    if (name.length() > maxLength) {
+      name = name.substring(0, maxLength) + "...";
+    }
+
+    job.setJobName(name);
+  }
+
   public int run(String[] args) throws Exception {
     if (args.length == 0 || (args.length == 1 && "--help".equals(args[0]))) {
       printUsage();
@@ -85,7 +99,7 @@ public class DistributedLzoIndexer extends Configured implements Tool {
     }
 
     Job job = new Job(getConf());
-    job.setJobName("Distributed Lzo Indexer " + Arrays.toString(args));
+    setJobName(job, args);
 
     job.setOutputKeyClass(Path.class);
     job.setOutputValueClass(LongWritable.class);

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -1,0 +1,90 @@
+package com.hadoop.compression.lzo;
+
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+
+public class TestDistLzoIndexerJobName extends TestCase {
+
+  public void testDefaultName() throws Exception {
+    String[] args = new String[]{
+        "hdfs://cluster/user/test/output/file-m-00000.lzo",
+    };
+
+    Job job = new Job(new Configuration(false));
+    DistributedLzoIndexer.setJobName(job, args);
+
+    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo]";
+
+    assertEquals(expected, job.getJobName());
+  }
+
+  public void testCustomeName() throws Exception {
+    String[] args = new String[]{
+        "ignored",
+    };
+    String customName = "-<Custom Job Name>-";
+
+    Configuration conf = new Configuration(false);
+    conf.set("lzo.indexer.distributed.job.name", customName);
+    Job job = new Job(conf);
+    DistributedLzoIndexer.setJobName(job, args);
+
+    assertEquals(customName, job.getJobName());
+  }
+
+  public void testCustomeNameTruncation() throws Exception {
+    String[] args = new String[]{
+        "ignored",
+    };
+
+    Configuration conf = new Configuration(false);
+    conf.set("lzo.indexer.distributed.job.name", "123456789");
+    conf.setInt("lzo.indexer.distributed.job.name.max.length", 5);
+    Job job = new Job(conf);
+    DistributedLzoIndexer.setJobName(job, args);
+
+    assertEquals("12345...", job.getJobName());
+  }
+
+  public void testDefaultLengthTruncation() throws Exception {
+    String[] args = new String[]{
+        "hdfs://cluster/user/test/output/file-m-00000.lzo",
+        "hdfs://cluster/user/test/output/file-m-00001.lzo",
+        "hdfs://cluster/user/test/output/file-m-00002.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+    };
+
+    Job job = new Job(new Configuration(false));
+    DistributedLzoIndexer.setJobName(job, args);
+
+    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo, hdfs://cluster/user/test/output/file-m-00001.lzo, hdfs://cluster/user/test/output/file-m-00002.lzo, hdfs://cluster/user/test/...";
+    // Truncated length should be 200 + 3 for the "..."
+    assertEquals(203, expected.length());
+
+    assertEquals(expected, job.getJobName());
+  }
+
+  public void testCustomLengthTruncation() throws Exception {
+    String[] args = new String[]{
+        "hdfs://cluster/user/test/output/file-m-00000.lzo",
+        "hdfs://cluster/user/test/output/file-m-00001.lzo",
+        "hdfs://cluster/user/test/output/file-m-00002.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+    };
+
+    Configuration conf = new Configuration(false);
+    conf.setInt("lzo.indexer.distributed.job.name.max.length", 50);
+    Job job = new Job(conf);
+    DistributedLzoIndexer.setJobName(job, args);
+
+    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/...";
+    // Truncated length should be 50 + 3 for the "..."
+    assertEquals(53, expected.length());
+
+    assertEquals(expected, job.getJobName());
+  }
+
+}

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -14,7 +14,7 @@ public class TestDistLzoIndexerJobName extends TestCase {
     Job job = new Job(new Configuration(false));
     DistributedLzoIndexer.setJobName(job, args);
 
-    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo]";
+    String expected = DistributedLzoIndexer.DEFAULT_JOB_NAME_PREFIX + " [hdfs://cluster/user/test/output/file-m-00000.lzo]";
 
     assertEquals(expected, job.getJobName());
   }

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -47,25 +47,6 @@ public class TestDistLzoIndexerJobName extends TestCase {
     assertEquals("12345...", job.getJobName());
   }
 
-  public void testDefaultLengthTruncation() throws Exception {
-    String[] args = new String[]{
-        "hdfs://cluster/user/test/output/file-m-00000.lzo",
-        "hdfs://cluster/user/test/output/file-m-00001.lzo",
-        "hdfs://cluster/user/test/output/file-m-00002.lzo",
-        "hdfs://cluster/user/test/output/file-m-00003.lzo",
-        "hdfs://cluster/user/test/output/file-m-00003.lzo",
-    };
-
-    Job job = new Job(new Configuration(false));
-    DistributedLzoIndexer.setJobName(job, args);
-
-    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo, hdfs://cluster/user/test/output/file-m-00001.lzo, hdfs://cluster/user/test/output/file-m-00002.lzo, hdfs://cluster/user/test/...";
-    // Truncated length should be 200 + 3 for the "..."
-    assertEquals(203, expected.length());
-
-    assertEquals(expected, job.getJobName());
-  }
-
   public void testCustomLengthTruncation() throws Exception {
     String[] args = new String[]{
         "hdfs://cluster/user/test/output/file-m-00000.lzo",

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -19,7 +19,7 @@ public class TestDistLzoIndexerJobName extends TestCase {
     assertEquals(expected, job.getJobName());
   }
 
-  public void testCustomeName() throws Exception {
+  public void testCustomName() throws Exception {
     String[] args = new String[]{
         "ignored",
     };
@@ -33,7 +33,7 @@ public class TestDistLzoIndexerJobName extends TestCase {
     assertEquals(customName, job.getJobName());
   }
 
-  public void testCustomeNameTruncation() throws Exception {
+  public void testCustomNameTruncation() throws Exception {
     String[] args = new String[]{
         "ignored",
     };

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -26,7 +26,7 @@ public class TestDistLzoIndexerJobName extends TestCase {
     String customName = "-<Custom Job Name>-";
 
     Configuration conf = new Configuration(false);
-    conf.set("lzo.indexer.distributed.job.name", customName);
+    conf.set(DistributedLzoIndexer.JOB_NAME_KEY, customName);
     Job job = new Job(conf);
     DistributedLzoIndexer.setJobName(job, args);
 
@@ -39,8 +39,8 @@ public class TestDistLzoIndexerJobName extends TestCase {
     };
 
     Configuration conf = new Configuration(false);
-    conf.set("lzo.indexer.distributed.job.name", "123456789");
-    conf.setInt("lzo.indexer.distributed.job.name.max.length", 5);
+    conf.set(DistributedLzoIndexer.JOB_NAME_KEY, "123456789");
+    conf.setInt(DistributedLzoIndexer.JOB_NAME_MAX_LENGTH_KEY, 5);
     Job job = new Job(conf);
     DistributedLzoIndexer.setJobName(job, args);
 
@@ -57,11 +57,11 @@ public class TestDistLzoIndexerJobName extends TestCase {
     };
 
     Configuration conf = new Configuration(false);
-    conf.setInt("lzo.indexer.distributed.job.name.max.length", 50);
+    conf.setInt(DistributedLzoIndexer.JOB_NAME_MAX_LENGTH_KEY, 50);
     Job job = new Job(conf);
     DistributedLzoIndexer.setJobName(job, args);
 
-    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/...";
+    String expected = DistributedLzoIndexer.DEFAULT_JOB_NAME_PREFIX + " [hdfs://cluster/user/test/...";
     // Truncated length should be 50 + 3 for the "..."
     assertEquals(53, expected.length());
 
@@ -78,11 +78,11 @@ public class TestDistLzoIndexerJobName extends TestCase {
     };
 
     Configuration conf = new Configuration(false);
-    conf.setInt("lzo.indexer.distributed.job.name.max.length", 0);
+    conf.setInt(DistributedLzoIndexer.JOB_NAME_MAX_LENGTH_KEY, 0);
     Job job = new Job(conf);
     DistributedLzoIndexer.setJobName(job, args);
 
-    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo, hdfs://cluster/user/test/output/file-m-00001.lzo, hdfs://cluster/user/test/output/file-m-00002.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo]";
+    String expected = DistributedLzoIndexer.DEFAULT_JOB_NAME_PREFIX + " [hdfs://cluster/user/test/output/file-m-00000.lzo, hdfs://cluster/user/test/output/file-m-00001.lzo, hdfs://cluster/user/test/output/file-m-00002.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo]";
     assertEquals(expected, job.getJobName());
   }
 

--- a/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestDistLzoIndexerJobName.java
@@ -87,4 +87,22 @@ public class TestDistLzoIndexerJobName extends TestCase {
     assertEquals(expected, job.getJobName());
   }
 
+  public void testDisabledTruncation() throws Exception {
+    String[] args = new String[]{
+        "hdfs://cluster/user/test/output/file-m-00000.lzo",
+        "hdfs://cluster/user/test/output/file-m-00001.lzo",
+        "hdfs://cluster/user/test/output/file-m-00002.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+        "hdfs://cluster/user/test/output/file-m-00003.lzo",
+    };
+
+    Configuration conf = new Configuration(false);
+    conf.setInt("lzo.indexer.distributed.job.name.max.length", 0);
+    Job job = new Job(conf);
+    DistributedLzoIndexer.setJobName(job, args);
+
+    String expected = "Distributed Lzo Indexer [hdfs://cluster/user/test/output/file-m-00000.lzo, hdfs://cluster/user/test/output/file-m-00001.lzo, hdfs://cluster/user/test/output/file-m-00002.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo, hdfs://cluster/user/test/output/file-m-00003.lzo]";
+    assertEquals(expected, job.getJobName());
+  }
+
 }


### PR DESCRIPTION
Truncates the job name to 200 characters by default and provides configuration options for overriding the name or length.

This fixes issue #25.