### PR TITLE
Make LzoTextInputFormat#listStatus thread safe for concurrent call

### DIFF
--- a/src/main/java/com/hadoop/mapred/DeprecatedLzoTextInputFormat.java
+++ b/src/main/java/com/hadoop/mapred/DeprecatedLzoTextInputFormat.java
@@ -21,10 +21,10 @@ package com.hadoop.mapred;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -63,7 +63,7 @@ import com.hadoop.compression.lzo.LzoInputFormatCommon;
 
 @SuppressWarnings("deprecation")
 public class DeprecatedLzoTextInputFormat extends TextInputFormat {
-  private final Map<Path, LzoIndex> indexes = new HashMap<Path, LzoIndex>();
+  private final Map<Path, LzoIndex> indexes = new ConcurrentHashMap<Path, LzoIndex>();
 
   @Override
   protected FileStatus[] listStatus(JobConf conf) throws IOException {

--- a/src/main/java/com/hadoop/mapreduce/LzoTextInputFormat.java
+++ b/src/main/java/com/hadoop/mapreduce/LzoTextInputFormat.java
@@ -20,10 +20,10 @@ package com.hadoop.mapreduce;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -53,7 +53,7 @@ import com.hadoop.compression.lzo.util.CompatibilityUtil;
  * behavior of this input format.
  */
 public class LzoTextInputFormat extends TextInputFormat {
-  private final Map<Path, LzoIndex> indexes = new HashMap<Path, LzoIndex>();
+  private final Map<Path, LzoIndex> indexes = new ConcurrentHashMap<Path, LzoIndex>();
 
   @Override
   protected List<FileStatus> listStatus(JobContext job) throws IOException {


### PR DESCRIPTION
```DeprecatedLzoTextInputFormat``` and ```LzoTextInputFormat``` does not thread-safe.
Use ```ConcurrentHashMap``` instead of ```HashMap```.