### PR TITLE
Remove LZO global lock "hack" that was for an old JVM bug

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
@@ -36,10 +36,6 @@ class LzoCompressor implements Compressor {
   private static final Log LOG = 
     LogFactory.getLog(LzoCompressor.class.getName());
 
-  // HACK - Use this as a global lock in the JNI layer
-  @SuppressWarnings({ "unchecked", "unused" })
-  private static Class clazz = LzoDecompressor.class;
-
   private int directBufferSize;
   private byte[] userBuf = null;
   private int userBufOff = 0, userBufLen = 0;

--- a/src/main/java/com/hadoop/compression/lzo/LzoDecompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoDecompressor.java
@@ -35,10 +35,6 @@ class LzoDecompressor implements Decompressor {
   private static final Log LOG = 
     LogFactory.getLog(LzoDecompressor.class.getName());
 
-  // HACK - Use this as a global lock in the JNI layer
-  @SuppressWarnings({ "unchecked", "unused" })
-  private static Class clazz = LzoDecompressor.class;
-
   /**
    * The minimum version of LZO that we can read.
    * Set to 1.0 since there were a couple header

--- a/src/main/native/impl/gpl-compression.h
+++ b/src/main/native/impl/gpl-compression.h
@@ -134,21 +134,6 @@ static FARPROC WINAPI do_dlsym(JNIEnv *env, HMODULE handle, LPCSTR symbol) {
 #endif
 // Windows part end
 
-
-#define LOCK_CLASS(env, clazz, classname) \
-  if ((*env)->MonitorEnter(env, clazz) != 0) { \
-    char exception_msg[128]; \
-    snprintf(exception_msg, 128, "Failed to lock %s", classname); \
-    THROW(env, "java/lang/InternalError", exception_msg); \
-  }
-
-#define UNLOCK_CLASS(env, clazz, classname) \
-  if ((*env)->MonitorExit(env, clazz) != 0) { \
-    char exception_msg[128]; \
-    snprintf(exception_msg, 128, "Failed to unlock %s", classname); \
-    THROW(env, "java/lang/InternalError", exception_msg); \
-  }
-
 /* A helper macro to convert the java 'function-pointer' to a void*. */
 #define FUNC_PTR(func_ptr) ((void*)((ptrdiff_t)(func_ptr)))
 

--- a/src/main/native/impl/lzo/LzoCompressor.c
+++ b/src/main/native/impl/lzo/LzoCompressor.c
@@ -107,7 +107,6 @@ typedef int
                                   lzo_bytep dst, lzo_uintp dst_len,
                                   lzo_voidp wrkmem, int compression_level );
 
-static jfieldID LzoCompressor_clazz;
 static jfieldID LzoCompressor_finish;
 static jfieldID LzoCompressor_finished;
 static jfieldID LzoCompressor_uncompressedDirectBuf;
@@ -145,8 +144,6 @@ Java_com_hadoop_compression_lzo_LzoCompressor_initIDs(
   }
 #endif
     
-  LzoCompressor_clazz = (*env)->GetStaticFieldID(env, class, "clazz", 
-                                                 "Ljava/lang/Class;");
   LzoCompressor_finish = (*env)->GetFieldID(env, class, "finish", "Z");
   LzoCompressor_finished = (*env)->GetFieldID(env, class, "finished", "Z");
   LzoCompressor_uncompressedDirectBuf = (*env)->GetFieldID(env, class, 
@@ -258,7 +255,6 @@ JNIEXPORT jint JNICALL
 Java_com_hadoop_compression_lzo_LzoCompressor_compressBytesDirect(
   JNIEnv *env, jobject this, jint compressor 
 	) {
-  jobject clazz = NULL;
   jobject uncompressed_direct_buf = NULL;
   lzo_uint uncompressed_direct_buf_len = 0;
   jobject compressed_direct_buf = NULL;
@@ -277,8 +273,6 @@ Java_com_hadoop_compression_lzo_LzoCompressor_compressBytesDirect(
   const char *lzo_compressor_function = lzo_compressors[compressor].function;
 
 	// Get members of LzoCompressor
-    clazz = (*env)->GetStaticObjectField(env, this, 
-                                                 LzoCompressor_clazz);
 	uncompressed_direct_buf = (*env)->GetObjectField(env, this, 
 									                    LzoCompressor_uncompressedDirectBuf);
 	uncompressed_direct_buf_len = (*env)->GetIntField(env, this, 
@@ -303,30 +297,21 @@ Java_com_hadoop_compression_lzo_LzoCompressor_compressBytesDirect(
                   LzoCompressor_lzoCompressor);
 
     // Get the input direct buffer
-    LOCK_CLASS(env, clazz, "LzoCompressor");
 	uncompressed_bytes = (*env)->GetDirectBufferAddress(env, 
                                             uncompressed_direct_buf);
-    UNLOCK_CLASS(env, clazz, "LzoCompressor");
-    
   if (uncompressed_bytes == 0) {
     	return (jint)0;
 	}
 	
     // Get the output direct buffer
-    LOCK_CLASS(env, clazz, "LzoCompressor");
 	compressed_bytes = (*env)->GetDirectBufferAddress(env, 
                                             compressed_direct_buf);
-    UNLOCK_CLASS(env, clazz, "LzoCompressor");
-    
   if (compressed_bytes == 0) {
 		return (jint)0;
 	}
 	
     // Get the working-memory direct buffer
-    LOCK_CLASS(env, clazz, "LzoCompressor");
     workmem = (*env)->GetDirectBufferAddress(env, working_memory_buf);
-    UNLOCK_CLASS(env, clazz, "LzoCompressor");
-    
   if (workmem == 0) {
     return (jint)0;
   }

--- a/src/main/native/impl/lzo/LzoDecompressor.c
+++ b/src/main/native/impl/lzo/LzoDecompressor.c
@@ -76,7 +76,6 @@ static char* lzo_decompressors[] = {
   /* 27 */  "lzo2a_decompress_safe"
 };
 
-static jfieldID LzoDecompressor_clazz;
 static jfieldID LzoDecompressor_finished;
 static jfieldID LzoDecompressor_compressedDirectBuf;
 static jfieldID LzoDecompressor_compressedDirectBufLen;
@@ -110,8 +109,6 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_initIDs(
   }
 #endif
     
-  LzoDecompressor_clazz = (*env)->GetStaticFieldID(env, class, "clazz", 
-                                                   "Ljava/lang/Class;");
   LzoDecompressor_finished = (*env)->GetFieldID(env, class, "finished", "Z");
   LzoDecompressor_compressedDirectBuf = (*env)->GetFieldID(env, class, 
                                                 "compressedDirectBuf", 
@@ -200,7 +197,6 @@ JNIEXPORT jint JNICALL
 Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
 	JNIEnv *env, jobject this, jint decompressor
 	) {
-  jobject clazz = NULL;
   jobject compressed_direct_buf = NULL;
   lzo_uint compressed_direct_buf_len = 0;
   jobject uncompressed_direct_buf = NULL;
@@ -215,8 +211,6 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
   const char *lzo_decompressor_function = lzo_decompressors[decompressor];
 
 	// Get members of LzoDecompressor
-	clazz = (*env)->GetStaticObjectField(env, this, 
-	                                             LzoDecompressor_clazz);
 	compressed_direct_buf = (*env)->GetObjectField(env, this,
                                               LzoDecompressor_compressedDirectBuf);
 	compressed_direct_buf_len = (*env)->GetIntField(env, this, 
@@ -231,21 +225,15 @@ Java_com_hadoop_compression_lzo_LzoDecompressor_decompressBytesDirect(
                                               LzoDecompressor_lzoDecompressor);
 
     // Get the input direct buffer
-    LOCK_CLASS(env, clazz, "LzoDecompressor");
 	uncompressed_bytes = (*env)->GetDirectBufferAddress(env, 
 											                    uncompressed_direct_buf);
-    UNLOCK_CLASS(env, clazz, "LzoDecompressor");
-    
  	if (uncompressed_bytes == 0) {
     return (jint)0;
 	}
 	
     // Get the output direct buffer
-    LOCK_CLASS(env, clazz, "LzoDecompressor");
 	compressed_bytes = (*env)->GetDirectBufferAddress(env, 
 										                    compressed_direct_buf);
-    UNLOCK_CLASS(env, clazz, "LzoDecompressor");
-
   if (compressed_bytes == 0) {
 		return (jint)0;
 	}


### PR DESCRIPTION
LzoCompressor and LzoDecompressor have a global lock protecting all GetDirectBufferAddress calls. This PR removes the global lock.

Apparently, the global lock's origin is [HADOOP-3604](https://issues.apache.org/jira/browse/HADOOP-3604), to work around [JDK-6852404](https://bugs.openjdk.java.net/browse/JDK-6852404), but which has been fixed for several years in all Java versions.

The global lock imposes a severe performance penalty in a highly multithreaded environment. I have a Java process with 64 threads on a 64-core machine to decompress LZO files concurrently, and around half of the threads are blocked on the global lock at any moment. The problem is not observed in a 16-way concurrency setup.