### PR TITLE
restore read split lzo file with index

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
@@ -102,6 +102,8 @@ public class LzoCodec implements Configurable, CompressionCodec {
     } catch (IOException e) {
       LOG.error("Could not find /hadoop-lzo-build.properties resource file with revision hash");
       return "UNKNOWN";
+    } catch (NullPointerException e){
+        return "UNKNOWN";
     }
   }
 


### PR DESCRIPTION
I use [presto](https://github.com/prestodb/presto) to read hive table which stores as DeprecatedLzoTextInputFormat.

DeprecatedLzoTextInputFormat.isSplitable function throws NullPointerException, because indexesMap does not contain the path in 'isSplitable' function. Maybe 'listStatus' function is not executed before.
```
Caused by: java.lang.NullPointerException
        at com.hadoop.mapred.DeprecatedLzoTextInputFormat.isSplitable(DeprecatedLzoTextInputFormat.java:103)
```

When I solve the NullPointerException, it throws IOException in LzopInputStream.getCompressedData, says 
```
Caused by: java.io.IOException: Compressed length 916527927 exceeds max block size 67108864 (probably corrupt file)
        at com.hadoop.compression.lzo.LzopInputStream.getCompressedData(LzopInputStream.java:295)
```

I guess it is wrong that LzopInputStream calculate the size of the compressed chunk. 

After careful examination, I find FSDataInputStream seek a wrong 'start' which is not start-stop offset of lzo block in DeprecatedLzoLineRecordReader constructor.

It can work normally, when I seek a right 'start' which is start offset of lzo block.

Please review the code, is my modification rigth?

Thanks.