### PR TITLE
Use https instead of http in urls

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hadoop-LZO is a project to bring splittable LZO compression to Hadoop.  LZO is a
 
 ### Origins
 
-This project builds off the great work done at [http://code.google.com/p/hadoop-gpl-compression](http://code.google.com/p/hadoop-gpl-compression).  As of issue 41, the differences in this codebase are the following.
+This project builds off the great work done at [https://code.google.com/p/hadoop-gpl-compression](https://code.google.com/p/hadoop-gpl-compression).  As of issue 41, the differences in this codebase are the following.
 
 - it fixes a few bugs in hadoop-gpl-compression -- notably, it allows the decompressor to read small or uncompressable lzo files, and also fixes the compressor to follow the lzo standard when compressing small or uncompressible chunks.  it also fixes a number of inconsistently caught and thrown exception cases that can occur when the lzo writer gets killed mid-stream, plus some other smaller issues (see commit log).
 - it adds the ability to work with Hadoop streaming via the com.apache.hadoop.mapred.DeprecatedLzoTextInputFormat class
@@ -16,17 +16,17 @@ This project builds off the great work done at [http://code.google.com/p/hadoop-
 
 LZO is a wonderful compression scheme to use with Hadoop because it's incredibly fast, and (with a bit of work) it's splittable.  Gzip is decently fast, but cannot take advantage of Hadoop's natural map splits because it's impossible to start decompressing a gzip stream starting at a random offset in the file.  LZO's block format makes it possible to start decompressing at certain specific offsets of the file -- those that start new LZO block boundaries.  In addition to providing LZO decompression support, these classes provide an in-process indexer (com.hadoop.compression.lzo.LzoIndexer) and a map-reduce style indexer which will read a set of LZO files and output the offsets of LZO block boundaries that occur near the natural Hadoop block boundaries.  This enables a large LZO file to be split into multiple mappers and processed in parallel.  Because it is compressed, less data is read off disk, minimizing the number of IOPS required.  And LZO decompression is so fast that the CPU stays ahead of the disk read, so there is no performance impact from having to decompress data as it's read off disk.
 
-You can read more about Hadoop, LZO, and how we're using it at Twitter at [http://www.cloudera.com/blog/2009/11/17/hadoop-at-twitter-part-1-splittable-lzo-compression/](http://www.cloudera.com/blog/2009/11/17/hadoop-at-twitter-part-1-splittable-lzo-compression/).
+You can read more about Hadoop, LZO, and how we're using it at Twitter at [https://www.cloudera.com/blog/2009/11/17/hadoop-at-twitter-part-1-splittable-lzo-compression/](https://www.cloudera.com/blog/2009/11/17/hadoop-at-twitter-part-1-splittable-lzo-compression/).
 
 ### Building and Configuring
 
-To get started, see [http://code.google.com/p/hadoop-gpl-compression/wiki/FAQ](http://code.google.com/p/hadoop-gpl-compression/wiki/FAQ).  This project is built exactly the same way; please follow the answer to "How do I configure Hadoop to use these classes?" on that page, or follow the summarized version here.
+To get started, see [https://code.google.com/p/hadoop-gpl-compression/wiki/FAQ](https://code.google.com/p/hadoop-gpl-compression/wiki/FAQ).  This project is built exactly the same way; please follow the answer to "How do I configure Hadoop to use these classes?" on that page, or follow the summarized version here.
 
 You need JDK 1.6 or higher to build hadoop-lzo (1.7 or higher on Mac OS).
 
 LZO 2.x is required, and most easily installed via the package manager on your system. If you choose to install manually for whatever reason (developer OSX machines is a common use-case) this is accomplished as follows:
 
-1. Download the latest LZO release from http://www.oberhumer.com/opensource/lzo/
+1. Download the latest LZO release from https://www.oberhumer.com/opensource/lzo/
 1. Configure LZO to build a shared library (required) and use a package-specific prefix (optional but recommended): `./configure --enable-shared --prefix /usr/local/lzo-2.06`
 1. Build and install LZO: `make && sudo make install`
 1. On Windows, you can build lzo2.dll with this command: `B\win64\vc_dll.bat`
@@ -93,11 +93,11 @@ Header files are not available in all Java installs. Double-check you are using 
 
 ### Maven repository
 
-The hadoop-lzo package is available at `http://maven.twttr.com/`.
+The hadoop-lzo package is available at `https://maven.twttr.com/`.
 
 For example, if you are using `ivy`, add the repository in `ivysettings.xml`:
 ```xml
-  <ibiblio name="twttr.com" m2compatible="true" root="http://maven.twttr.com/"/>
+  <ibiblio name="twttr.com" m2compatible="true" root="https://maven.twttr.com/"/>
 ```
 
 And include hadoop-lzo as a dependency:

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.hadoop.gplcompression</groupId>
   <artifactId>hadoop-lzo</artifactId>
@@ -26,7 +26,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 

--- a/src/main/java/com/hadoop/compression/lzo/CChecksum.java
+++ b/src/main/java/com/hadoop/compression/lzo/CChecksum.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
  
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/DChecksum.java
+++ b/src/main/java/com/hadoop/compression/lzo/DChecksum.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
  
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/GPLNativeCodeLoader.java
+++ b/src/main/java/com/hadoop/compression/lzo/GPLNativeCodeLoader.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
  
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;
@@ -38,7 +38,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 /**
  * A {@link org.apache.hadoop.io.compress.CompressionCodec} for a streaming
  * <b>lzo</b> compression/decompression pair.
- * http://www.oberhumer.com/opensource/lzo/
+ * https://www.oberhumer.com/opensource/lzo/
  *
  */
 public class LzoCodec implements Configurable, CompressionCodec {
@@ -119,7 +119,7 @@ public class LzoCodec implements Configurable, CompressionCodec {
     }
 
     /**
-     * <b>http://www.oberhumer.com/opensource/lzo/lzofaq.php</b>
+     * <b>https://www.oberhumer.com/opensource/lzo/lzofaq.php</b>
      *
      * How much can my data expand during compression ?
      * ================================================

--- a/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCompressor.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;
@@ -29,7 +29,7 @@ import org.apache.hadoop.io.compress.Compressor;
 
 /**
  * A {@link Compressor} based on the lzo algorithm.
- * http://www.oberhumer.com/opensource/lzo/
+ * https://www.oberhumer.com/opensource/lzo/
  * 
  */
 class LzoCompressor implements Compressor {

--- a/src/main/java/com/hadoop/compression/lzo/LzoDecompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoDecompressor.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;
@@ -28,7 +28,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 
 /**
  * A {@link Decompressor} based on the lzo algorithm.
- * http://www.oberhumer.com/opensource/lzo/
+ * https://www.oberhumer.com/opensource/lzo/
  * 
  */
 class LzoDecompressor implements Decompressor {

--- a/src/main/java/com/hadoop/compression/lzo/LzoIndex.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoIndex.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzoIndexer.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoIndexer.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzoInputFormatCommon.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoInputFormatCommon.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;
@@ -36,7 +36,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 /**
  * A {@link CompressionCodec} for a streaming
  * <b>lzo</b> compression/decompression pair compatible with lzop.
- * http://www.lzop.org/
+ * https://www.lzop.org/
  */
 public class LzopCodec extends LzoCodec {
 

--- a/src/main/java/com/hadoop/compression/lzo/LzopDecompressor.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopDecompressor.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzopInputStream.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopInputStream.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/main/java/com/hadoop/compression/lzo/LzopOutputStream.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopOutputStream.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;
@@ -127,7 +127,7 @@ public class LzopOutputStream extends CompressorStream {
     // bug we pulled down the implementation of the superclass, which
     // is overly general. Thus this function is not quite as succint
     // as it could be, now that it's LZOP-specific.
-    // See: http://github.com/toddlipcon/hadoop-lzo/commit/5fe6dd4736a73fa33b86656ce8aeb011e7f2046c
+    // See: https://github.com/toddlipcon/hadoop-lzo/commit/5fe6dd4736a73fa33b86656ce8aeb011e7f2046c
 
     // Sanity checks
     if (compressor.finished()) {

--- a/src/main/java/com/hadoop/mapred/DeprecatedLzoLineRecordReader.java
+++ b/src/main/java/com/hadoop/mapred/DeprecatedLzoLineRecordReader.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.mapred;

--- a/src/main/java/com/hadoop/mapred/DeprecatedLzoTextInputFormat.java
+++ b/src/main/java/com/hadoop/mapred/DeprecatedLzoTextInputFormat.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.mapred;

--- a/src/main/java/com/hadoop/mapreduce/LzoLineRecordReader.java
+++ b/src/main/java/com/hadoop/mapreduce/LzoLineRecordReader.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.mapreduce;

--- a/src/main/java/com/hadoop/mapreduce/LzoTextInputFormat.java
+++ b/src/main/java/com/hadoop/mapreduce/LzoTextInputFormat.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
  
 package com.hadoop.mapreduce;

--- a/src/main/java/com/quicklz/QuickLZ.java
+++ b/src/main/java/com/quicklz/QuickLZ.java
@@ -5,7 +5,7 @@
 // QuickLZ can be used for free under the GPL-1 or GPL-2 license
 // (where anything released into public must be open source) or under
 // a commercial license if such has been acquired (see
-// http://www.quicklz.com/order.html). The commercial license does not
+// https://www.quicklz.com/order.html). The commercial license does not
 // cover derived or ported versions created by third parties under
 // GPL.
 //

--- a/src/main/java/org/apache/hadoop/io/compress/LzoCodec.java
+++ b/src/main/java/org/apache/hadoop/io/compress/LzoCodec.java
@@ -12,7 +12,7 @@
  * details.
  * 
  * You should have received a copy of the GNU General Public License along with
- * Hadoop-Gpl-Compression. If not, see <http://www.gnu.org/licenses/>.
+ * Hadoop-Gpl-Compression. If not, see <https://www.gnu.org/licenses/>.
  */
  
 package org.apache.hadoop.io.compress;

--- a/src/main/native/Makefile.am
+++ b/src/main/native/Makefile.am
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo

--- a/src/main/native/Makefile.in
+++ b/src/main/native/Makefile.in
@@ -224,7 +224,7 @@ top_srcdir = @top_srcdir@
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo
 AM_LDFLAGS = @JNI_LDFLAGS@

--- a/src/main/native/config/ltmain.sh
+++ b/src/main/native/config/ltmain.sh
@@ -24,7 +24,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GNU Libtool; see the file COPYING.  If not, a copy
-# can be downloaded from http://www.gnu.org/licenses/gpl.html,
+# can be downloaded from https://www.gnu.org/licenses/gpl.html,
 # or obtained by writing to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 

--- a/src/main/native/configure
+++ b/src/main/native/configure
@@ -11657,7 +11657,7 @@ else
 #	if defined __xlc__ || defined __GNUC__
 	 /* Catch a bug in IBM AIX xlc compiler version 6.0.0.0
 	    reported by James Lemley on 2005-10-05; see
-	    http://lists.gnu.org/archive/html/bug-coreutils/2005-10/msg00086.html
+	    https://lists.gnu.org/archive/html/bug-coreutils/2005-10/msg00086.html
 	    This test is not quite right, since xlc is allowed to
 	    reject this program, as the initializer for xlcbug is
 	    not one of the forms that C requires support for.
@@ -11674,8 +11674,8 @@ else
 	 int xlcbug = 1 / (&(digs + 5)[-2 + (bool) 1] == &digs[4] ? 1 : -1);
 #	endif
 	/* Catch a bug in an HP-UX C compiler.  See
-	   http://gcc.gnu.org/ml/gcc-patches/2003-12/msg02303.html
-	   http://lists.gnu.org/archive/html/bug-coreutils/2005-11/msg00161.html
+	   https://gcc.gnu.org/ml/gcc-patches/2003-12/msg02303.html
+	   https://lists.gnu.org/archive/html/bug-coreutils/2005-11/msg00161.html
 	 */
 	_Bool q = true;
 	_Bool *pq = &q;
@@ -13724,7 +13724,7 @@ $as_echo X"$file" |
 #
 # You should have received a copy of the GNU General Public License
 # along with GNU Libtool; see the file COPYING.  If not, a copy
-# can be downloaded from http://www.gnu.org/licenses/gpl.html, or
+# can be downloaded from https://www.gnu.org/licenses/gpl.html, or
 # obtained by writing to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 

--- a/src/main/native/configure.ac
+++ b/src/main/native/configure.ac
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.

--- a/src/main/native/gplcompression.sln
+++ b/src/main/native/gplcompression.sln
@@ -16,7 +16,7 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 
 Project("{EAAEC089-7163-4E57-96A1-B61BF66B3F72}") = "gplcompression", "gplcompression.vcxproj", "{A8EC1579-8E95-4C0B-A462-4C3D625CDC39}"
 EndProject

--- a/src/main/native/gplcompression.vcxproj
+++ b/src/main/native/gplcompression.vcxproj
@@ -15,10 +15,10 @@
  
   You should have received a copy of the GNU General Public License
   along with Hadoop-Gpl-Compression.  If not, see
-  <http://www.gnu.org/licenses/>.
+  <https://www.gnu.org/licenses/>.
 -->
 
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="https://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/src/main/native/impl/gpl-compression.h
+++ b/src/main/native/impl/gpl-compression.h
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 /**

--- a/src/main/native/impl/lzo/LzoCompressor.c
+++ b/src/main/native/impl/lzo/LzoCompressor.c
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 #include "gpl-compression.h"

--- a/src/main/native/impl/lzo/LzoDecompressor.c
+++ b/src/main/native/impl/lzo/LzoDecompressor.c
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 #include "gpl-compression.h"

--- a/src/main/native/impl/lzo/lzo.h
+++ b/src/main/native/impl/lzo/lzo.h
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 #if !defined LZO_H

--- a/src/main/native/m4/compression_utils.m4
+++ b/src/main/native/m4/compression_utils.m4
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 
 # Check to see if the install program supports -C
 # If so, use "install -C" for the headers. Otherwise, every install

--- a/src/main/native/m4/libtool.m4
+++ b/src/main/native/m4/libtool.m4
@@ -32,7 +32,7 @@ m4_define([_LT_COPYING], [dnl
 #
 # You should have received a copy of the GNU General Public License
 # along with GNU Libtool; see the file COPYING.  If not, a copy
-# can be downloaded from http://www.gnu.org/licenses/gpl.html, or
+# can be downloaded from https://www.gnu.org/licenses/gpl.html, or
 # obtained by writing to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 ])

--- a/src/main/native/packageNativeHadoop.sh
+++ b/src/main/native/packageNativeHadoop.sh
@@ -7,7 +7,7 @@
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/hadoop/compression/lzo/TestLzopInputStream.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestLzopInputStream.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/test/java/com/hadoop/compression/lzo/TestLzopOutputStream.java
+++ b/src/test/java/com/hadoop/compression/lzo/TestLzopOutputStream.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
 
 package com.hadoop.compression.lzo;

--- a/src/test/java/com/hadoop/mapreduce/TestLzoTextInputFormat.java
+++ b/src/test/java/com/hadoop/mapreduce/TestLzoTextInputFormat.java
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Hadoop-Gpl-Compression.  If not, see
- * <http://www.gnu.org/licenses/>.
+ * <https://www.gnu.org/licenses/>.
  */
  
 package com.hadoop.mapreduce;

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Hadoop-Gpl-Compression.  If not, see
-# <http://www.gnu.org/licenses/>.
+# <https://www.gnu.org/licenses/>.
 # log4j configuration used during build and unit tests
 
 log4j.rootLogger=info,stdout


### PR DESCRIPTION
This PR changes every instance of an http url to its https version for security reasons.