### PR TITLE
Fix the compression function wrong call for lzo1x

### DIFF
--- a/src/main/native/impl/lzo/LzoCompressor.c
+++ b/src/main/native/impl/lzo/LzoCompressor.c
@@ -85,9 +85,9 @@ static lzo_compressor lzo_compressors[] = {
 
   /** lzo1x compressors */
   /* 34 */  {"lzo1x_1_compress", LZO1X_1_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
-  /* 35 */  {"lzo1x_11_compress", LZO1X_1_11_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
-  /* 36 */  {"lzo1x_12_compress", LZO1X_1_12_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
-  /* 37 */  {"lzo1x_15_compress", LZO1X_1_15_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
+  /* 35 */  {"lzo1x_1_11_compress", LZO1X_1_11_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
+  /* 36 */  {"lzo1x_1_12_compress", LZO1X_1_12_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
+  /* 37 */  {"lzo1x_1_15_compress", LZO1X_1_15_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
   /* 38 */  {"lzo1x_999_compress", LZO1X_999_MEM_COMPRESS, UNDEFINED_COMPRESSION_LEVEL},
 
   /** lzo1y compressors */


### PR DESCRIPTION
replace lzo1x_11_compress to lzo1x_1_11_compress
replace lzo1x_12_compress to lzo1x_1_12_compress
replace lzo1x_15_compress to lzo1x_1_15_compress