### PR TITLE
Add loongarch64 build support

### DIFF
--- a/src/main/native/Makefile.am
+++ b/src/main/native/Makefile.am
@@ -18,7 +18,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo
 AM_LDFLAGS = @JNI_LDFLAGS@
 AM_CFLAGS = -g -Wall -fPIC -O2
-ifneq ($(OS_ARCH),aarch64)
+ifeq ($(filter aarch64 loongarch64, $(OS_ARCH)),)
   AM_CFLAGS += -m$(JVM_DATA_MODEL)
 endif
 

--- a/src/main/native/Makefile.in
+++ b/src/main/native/Makefile.in
@@ -229,7 +229,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = @JNI_CPPFLAGS@ -I$(srcdir)/impl -Isrc/com/hadoop/compression/lzo
 AM_LDFLAGS = @JNI_LDFLAGS@
 AM_CFLAGS = -g -Wall -fPIC -O2
-ifneq ($(OS_ARCH),aarch64)
+ifeq ($(filter aarch64 loongarch64, $(OS_ARCH)),)
   AM_CFLAGS += -m$(JVM_DATA_MODEL)
 endif
 

--- a/src/main/native/config/config.guess
+++ b/src/main/native/config/config.guess
@@ -859,6 +859,9 @@ EOF
     ia64:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
 	exit 0 ;;
+    loongarch64:Linux:*:*)
+	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
+	exit 0 ;;
     m32r*:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-${LIBC}
 	exit 0 ;;


### PR DESCRIPTION
The purpose of thie PR is to build `hadoop-lzo` on `loongarch64`.

At the same time I notice that the time of `config.guess` is `2005-02-10`, should it be upgraded? 